### PR TITLE
fix: handle null values from nvim 0.12

### DIFF
--- a/lua/bqls/commands.lua
+++ b/lua/bqls/commands.lua
@@ -3,10 +3,14 @@ local api = vim.api
 
 local M = {}
 
----@param data {columns: table<string>, data: table<table<any>>}
+---@param data {columns: table<string>, data: table<table<any>> | vim.NIL}
 M.convert_data_to_markdown = function(data)
   local txt = ''
-  if not data.columns or not data.data then
+  -- nvim 0.12 changed how null values are handled
+  -- see https://github.com/neovim/neovim/pull/34849
+  --
+  -- keep checking if nil for compatibily with nvim 0.11
+  if not data.columns or not data.data or data.data == vim.NIL or data.columns == vim.NIL then
     return txt
   end
   for _, column in pairs(data.columns) do


### PR DESCRIPTION
Follow-up #12 

Addresses my suggestions from this [comment](https://github.com/kitagry/bqls.nvim/pull/12#issuecomment-3264411248).

Note: I opted for handling the result from nvim's side, but as I mentioned in the comment, the server could be updated instead.

By the way, any thoughts on using `workspace_required`, coupled with a "custom" file? I guess we could add a `.bqls`, even if it's just a "placeholder".

I also took a stab at creating a user command to switch between projects (not committed yet), but I think it's not working properly. My implementation is pretty much copy-pasted from the README, though. I think the problem might be on the server side: at first, the new project isn't "detected", it's only after saving the file that _everything_ goes back to normal (i.e., at first queries don't work, saving the file is a requirement).