### PR TITLE
Scope bqls custom LSP requests to the bqls client

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.lua'
+  pull_request:
+    paths:
+      - '**.lua'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+test:
+	nvim --headless --noplugin -u tests/minimal_init.lua \
+		-c "PlenaryBustedDirectory tests/bqls { minimal_init = 'tests/minimal_init.lua' }"

--- a/README.md
+++ b/README.md
@@ -130,3 +130,11 @@ vim.keymap.set("n", "<leader>db", require("bqls").sidebar.toggle)
 Press `f` in the sidebar to search tables across all displayed projects. Results are shown via telescope picker (falls back to `vim.ui.select` if telescope is not installed). Selecting a result opens the table in a non-sidebar window.
 
 > **Note:** Table search requires bqls server **v0.6.0 or above**.
+
+## Development
+
+Run the test suite (requires [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)):
+
+```sh
+make test
+```

--- a/lua/bqls/commands.lua
+++ b/lua/bqls/commands.lua
@@ -68,12 +68,15 @@ M.execute_query_handler = function(err, result, params)
 			uri = result.textDocument.uri,
 		},
 	}
-	vim.lsp.buf_request(
-		bufnr,
-		"bqls/virtualTextDocument",
-		virtual_text_document_params,
-		require("bqls").handlers["bqls/virtualTextDocument"]
-	)
+	local client = vim.lsp.get_client_by_id(params.client_id)
+	if client then
+		client:request(
+			"bqls/virtualTextDocument",
+			virtual_text_document_params,
+			require("bqls").handlers["bqls/virtualTextDocument"],
+			bufnr
+		)
+	end
 end
 
 ---@class JobHistory
@@ -155,12 +158,15 @@ M.list_job_history_handler = function(err, result, params)
 				uri = item.textDocument.uri,
 			},
 		}
-		vim.lsp.buf_request(
-			bufnr,
-			"bqls/virtualTextDocument",
-			virtual_text_document_params,
-			require("bqls").handlers["bqls/virtualTextDocument"]
-		)
+		local client = vim.lsp.get_client_by_id(params.client_id)
+		if client then
+			client:request(
+				"bqls/virtualTextDocument",
+				virtual_text_document_params,
+				require("bqls").handlers["bqls/virtualTextDocument"],
+				bufnr
+			)
+		end
 	end
 
 	if pcall(require, "telescope") then

--- a/lua/bqls/init.lua
+++ b/lua/bqls/init.lua
@@ -48,12 +48,7 @@ local function definition_handler(err, result, ctx, config)
 					uri = uri,
 				},
 			}
-			vim.lsp.buf_request(
-				0,
-				"bqls/virtualTextDocument",
-				params,
-				require("bqls").handlers["bqls/virtualTextDocument"]
-			)
+			client:request("bqls/virtualTextDocument", params, require("bqls").handlers["bqls/virtualTextDocument"], 0)
 			res["uri"] = uri
 			res["targetUri"] = uri
 		end

--- a/lua/bqls/sidebar.lua
+++ b/lua/bqls/sidebar.lua
@@ -112,7 +112,7 @@ local function open_table(node, how)
 	end
 
 	api.nvim_win_set_buf(api.nvim_get_current_win(), target_bufnr)
-	vim.lsp.buf_request(
+	require("bqls.util").bqls_request(
 		target_bufnr,
 		"bqls/virtualTextDocument",
 		{ textDocument = { uri = uri } },

--- a/lua/bqls/util.lua
+++ b/lua/bqls/util.lua
@@ -1,0 +1,20 @@
+local M = {}
+
+--- `bqls/*` methods are custom LSP methods that only the bqls server
+--- understands. `vim.lsp.buf_request` broadcasts to every client attached
+--- to the buffer, so other clients (e.g. copilot) reply with MethodNotFound.
+--- Send these requests to the bqls client specifically instead.
+---@param bufnr integer
+---@param method string
+---@param params table
+---@param handler function
+function M.bqls_request(bufnr, method, params, handler)
+	local client = vim.lsp.get_clients({ name = "bqls" })[1]
+	if not client then
+		vim.notify("bqls: bqls client is not attached", vim.log.levels.ERROR)
+		return
+	end
+	client:request(method, params, handler, bufnr)
+end
+
+return M

--- a/plugin/bqls.lua
+++ b/plugin/bqls.lua
@@ -48,6 +48,11 @@ vim.api.nvim_create_autocmd("BufNew", {
 				uri = ev.file,
 			},
 		}
-		vim.lsp.buf_request(0, "bqls/virtualTextDocument", params, require("bqls").handlers["bqls/virtualTextDocument"])
+		require("bqls.util").bqls_request(
+			0,
+			"bqls/virtualTextDocument",
+			params,
+			require("bqls").handlers["bqls/virtualTextDocument"]
+		)
 	end,
 })

--- a/tests/bqls/commands_spec.lua
+++ b/tests/bqls/commands_spec.lua
@@ -1,0 +1,68 @@
+local commands = require("bqls.commands")
+
+describe("bqls.commands.convert_data_to_markdown", function()
+	it("renders columns and rows as a markdown table", function()
+		local result = commands.convert_data_to_markdown({
+			columns = { "id", "name" },
+			data = {
+				{ 1, "alice" },
+				{ 2, "bob" },
+			},
+		})
+
+		assert.are.same(
+			"| id | name  |\n| :---: | :---: |\n| 1 | alice  |\n| 2 | bob  |\n",
+			result,
+			"expected a markdown table with a header row, divider, and one row per record"
+		)
+	end)
+
+	it("renders only the header and divider when there are no rows", function()
+		local result = commands.convert_data_to_markdown({
+			columns = { "id" },
+			data = {},
+		})
+
+		assert.are.same("| id  |\n| :---: |\n", result, "expected no data rows when data is empty")
+	end)
+
+	it("returns an empty string when columns are missing", function()
+		local result = commands.convert_data_to_markdown({ data = { { 1 } } })
+
+		assert.are.same("", result, "expected no output when there are no columns to render")
+	end)
+
+	it("returns an empty string when data is vim.NIL", function()
+		local result = commands.convert_data_to_markdown({ columns = { "id" }, data = vim.NIL })
+
+		assert.are.same("", result, "expected no output when data is the JSON null sentinel")
+	end)
+
+	describe("cell value formatting", function()
+		local cases = {
+			{ name = "boolean true becomes the string true", value = true, expected = "true" },
+			{ name = "boolean false becomes the string false", value = false, expected = "false" },
+			{ name = "vim.NIL becomes the string NULL", value = vim.NIL, expected = "NULL" },
+			{
+				name = "a table value becomes its JSON encoding",
+				value = { a = 1 },
+				expected = vim.json.encode({ a = 1 }),
+			},
+		}
+
+		for _, case in ipairs(cases) do
+			it(case.name, function()
+				local result = commands.convert_data_to_markdown({
+					columns = { "value" },
+					data = { { case.value } },
+				})
+
+				assert.are.same(
+					"| value  |\n| :---: |\n| " .. case.expected .. "  |\n",
+					result,
+					"expected the cell to render as " .. case.expected
+				)
+			end)
+		end
+	end)
+end)

--- a/tests/bqls/util_spec.lua
+++ b/tests/bqls/util_spec.lua
@@ -1,0 +1,64 @@
+local util = require("bqls.util")
+
+describe("bqls.util.bqls_request", function()
+	local original_get_clients
+	local original_notify
+
+	before_each(function()
+		original_get_clients = vim.lsp.get_clients
+		original_notify = vim.notify
+	end)
+
+	after_each(function()
+		vim.lsp.get_clients = original_get_clients
+		vim.notify = original_notify
+	end)
+
+	it("sends the request only to the client named bqls, not every attached client", function()
+		local requested
+		local get_clients_opts
+		local bqls_client = {
+			request = function(self, method, params, handler, bufnr)
+				requested = { method = method, params = params, bufnr = bufnr }
+			end,
+		}
+
+		vim.lsp.get_clients = function(opts)
+			get_clients_opts = opts
+			return { bqls_client }
+		end
+
+		local params = { textDocument = { uri = "bqls://project/foo" } }
+		util.bqls_request(3, "bqls/virtualTextDocument", params, function() end)
+
+		assert.are.same(
+			"bqls",
+			get_clients_opts.name,
+			"expected clients to be looked up by name=bqls instead of broadcasting to every attached client"
+		)
+		assert.are.same({
+			method = "bqls/virtualTextDocument",
+			params = params,
+			bufnr = 3,
+		}, requested, "expected the bqls client to receive the request with the original method/params/bufnr")
+	end)
+
+	it("does not send a request when no bqls client is attached", function()
+		vim.lsp.get_clients = function()
+			return {}
+		end
+
+		local notified = false
+		vim.notify = function()
+			notified = true
+		end
+
+		local handler_called = false
+		util.bqls_request(3, "bqls/virtualTextDocument", {}, function()
+			handler_called = true
+		end)
+
+		assert.is_true(notified, "expected a notification when no bqls client is attached")
+		assert.is_false(handler_called, "handler must not run since no request was ever sent")
+	end)
+end)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,14 @@
+local plenary_lazy_path = vim.fn.stdpath("data") .. "/lazy/plenary.nvim"
+local plenary_ci_path = "/tmp/plenary.nvim"
+
+if vim.fn.isdirectory(plenary_lazy_path) == 1 then
+	vim.opt.rtp:append(plenary_lazy_path)
+else
+	if vim.fn.isdirectory(plenary_ci_path) == 0 then
+		vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/nvim-lua/plenary.nvim", plenary_ci_path })
+	end
+	vim.opt.rtp:append(plenary_ci_path)
+end
+
+vim.opt.rtp:append(".")
+vim.cmd("runtime plugin/plenary.vim")


### PR DESCRIPTION
## Summary
- `vim.lsp.buf_request()` broadcasts to every LSP client attached to the buffer, so bqls's custom `bqls/virtualTextDocument` requests were also being sent to other clients (e.g. copilot), which don't understand the method and reply with `MethodNotFound`. Requests are now sent to the bqls client specifically (via a new `bqls.util.bqls_request` helper, or directly via the already-known bqls client where available).
- Added a plenary.nvim-based test suite (`tests/`, `Makefile`) plus a GitHub Actions workflow to run it on lua changes, since none existed before. Includes regression tests for the new helper and for `commands.convert_data_to_markdown`.

## Test plan
- [x] `make test` — all 10 specs pass
- [x] `stylua --check .` passes
- [ ] Manually verify `gd` on a `bqls://` link no longer produces a `MethodNotFound` error when copilot (or another LSP) is attached to the same buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)