### PR TITLE
Support async bqls/virtualTextDocument fetching

### DIFF
--- a/lsp/bqls.lua
+++ b/lsp/bqls.lua
@@ -8,4 +8,5 @@ return {
 	root_markers = { ".git" },
 	handlers = require("bqls").handlers,
 	settings = {},
+	init_options = { supports_async_virtual_text_document = true },
 }

--- a/lua/bqls/init.lua
+++ b/lua/bqls/init.lua
@@ -10,18 +10,16 @@ M.setup = function(config)
 	M.sidebar.setup(config)
 end
 
-local function virtual_text_document_handler(uri, res, client_id)
-	if not res then
-		return nil
-	end
+-- Details received via bqls/publishVirtualTextDocument, keyed by uri, held
+-- until the matching preview notification arrives so the two can be
+-- rendered together in the same buffer.
+local pending_details = {}
 
-	local lines = util.convert_input_to_markdown_lines(res.contents)
-
-	local result_lines = vim.split(commands.convert_data_to_markdown(res.result), "\n")
-
-	vim.list_extend(lines, result_lines)
-	local bufnr = vim.uri_to_bufnr(uri)
-
+local function write_virtual_document(bufnr, lines, client_id)
+	-- A buffer whose contents already arrived (e.g. "details") is
+	-- readonly, so re-enable writes before overwriting it with the next
+	-- notification (e.g. "preview") to avoid a W10 warning.
+	vim.api.nvim_set_option_value("readonly", false, { buf = bufnr })
 	vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 	vim.api.nvim_set_option_value("readonly", true, { buf = bufnr })
@@ -29,6 +27,55 @@ local function virtual_text_document_handler(uri, res, client_id)
 	vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
 	vim.api.nvim_set_option_value("filetype", "markdown", { buf = bufnr })
 	vim.lsp.buf_attach_client(bufnr, client_id)
+end
+
+local function virtual_text_document_handler(uri, res, client_id)
+	if not res then
+		return nil
+	end
+
+	local bufnr = vim.uri_to_bufnr(uri)
+
+	if res.pending then
+		-- Discard details from any earlier fetch of this uri: the server
+		-- only publishes notifications for the latest request, so a stale
+		-- cache entry here would otherwise leak into the next preview.
+		pending_details[uri] = nil
+		write_virtual_document(bufnr, { "Loading..." }, client_id)
+		return
+	end
+
+	local lines = util.convert_input_to_markdown_lines(res.contents)
+
+	local result_lines = vim.split(commands.convert_data_to_markdown(res.result), "\n")
+
+	vim.list_extend(lines, result_lines)
+	write_virtual_document(bufnr, lines, client_id)
+end
+
+local function publish_virtual_text_document_handler(_, params, ctx)
+	local uri = params.textDocument.uri
+	local bufnr = vim.uri_to_bufnr(uri)
+
+	if params.error then
+		pending_details[uri] = nil
+		write_virtual_document(bufnr, { "Error: " .. params.error }, ctx.client_id)
+		return
+	end
+
+	if params.kind == "details" then
+		local lines = util.convert_input_to_markdown_lines(params.contents)
+		pending_details[uri] = lines
+		local buffer_lines = vim.list_extend({}, lines)
+		vim.list_extend(buffer_lines, { "", "Loading preview..." })
+		write_virtual_document(bufnr, buffer_lines, ctx.client_id)
+	elseif params.kind == "preview" then
+		local lines = pending_details[uri] or {}
+		pending_details[uri] = nil
+		local result_lines = vim.split(commands.convert_data_to_markdown(params.result), "\n")
+		vim.list_extend(lines, result_lines)
+		write_virtual_document(bufnr, lines, ctx.client_id)
+	end
 end
 
 local function definition_handler(err, result, ctx, config)
@@ -78,6 +125,7 @@ M.handlers = {
 
 		virtual_text_document_handler(ctx.params.textDocument.uri, result, ctx.client_id)
 	end,
+	["bqls/publishVirtualTextDocument"] = publish_virtual_text_document_handler,
 }
 
 return M

--- a/plugin/bqls.lua
+++ b/plugin/bqls.lua
@@ -10,6 +10,7 @@ configs.bqls = {
 		filetypes = { "sql", "bigquery" },
 		handlers = require("bqls").handlers,
 		single_file_support = true,
+		init_options = { supports_async_virtual_text_document = true },
 	},
 }
 

--- a/tests/bqls/init_spec.lua
+++ b/tests/bqls/init_spec.lua
@@ -1,0 +1,125 @@
+local bqls = require("bqls")
+
+local function get_lines(bufnr)
+	return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+end
+
+describe("bqls/virtualTextDocument handler", function()
+	it("renders contents and result synchronously when the response is not pending", function()
+		local uri = "bqls://project/p/dataset/d/table/sync"
+		local bufnr = vim.uri_to_bufnr(uri)
+
+		bqls.handlers["bqls/virtualTextDocument"](nil, {
+			contents = { "# sync table" },
+			result = { columns = { "id" }, data = { { 1 } } },
+		}, {
+			client_id = 0,
+			params = { textDocument = { uri = uri } },
+		})
+
+		local lines = get_lines(bufnr)
+		assert.are.same("# sync table", lines[1])
+		assert.is_true(vim.tbl_contains(lines, "| id  |"), "expected the result table header in the buffer")
+	end)
+
+	it("shows a loading placeholder instead of crashing when the response is pending", function()
+		local uri = "bqls://project/p/dataset/d/table/pending"
+		local bufnr = vim.uri_to_bufnr(uri)
+
+		bqls.handlers["bqls/virtualTextDocument"](nil, { pending = true }, {
+			client_id = 0,
+			params = { textDocument = { uri = uri } },
+		})
+
+		assert.are.same({ "Loading..." }, get_lines(bufnr))
+	end)
+end)
+
+describe("bqls/publishVirtualTextDocument handler", function()
+	it("renders details and marks the preview as still loading", function()
+		local uri = "bqls://project/p/dataset/d/table/details"
+		local bufnr = vim.uri_to_bufnr(uri)
+
+		bqls.handlers["bqls/publishVirtualTextDocument"](nil, {
+			textDocument = { uri = uri },
+			kind = "details",
+			contents = { "# details table" },
+		}, { client_id = 0 })
+
+		local lines = get_lines(bufnr)
+		assert.are.same("# details table", lines[1])
+		assert.is_true(
+			vim.tbl_contains(lines, "Loading preview..."),
+			"expected a placeholder for the not-yet-arrived preview"
+		)
+	end)
+
+	it("appends the preview table below the previously rendered details", function()
+		local uri = "bqls://project/p/dataset/d/table/preview"
+		local bufnr = vim.uri_to_bufnr(uri)
+
+		bqls.handlers["bqls/publishVirtualTextDocument"](nil, {
+			textDocument = { uri = uri },
+			kind = "details",
+			contents = { "# preview table" },
+		}, { client_id = 0 })
+
+		bqls.handlers["bqls/publishVirtualTextDocument"](nil, {
+			textDocument = { uri = uri },
+			kind = "preview",
+			result = { columns = { "id" }, data = { { 1 } } },
+		}, { client_id = 0 })
+
+		local lines = get_lines(bufnr)
+		assert.are.same("# preview table", lines[1])
+		assert.is_true(vim.tbl_contains(lines, "| id  |"), "expected the preview table header in the buffer")
+		assert.is_false(
+			vim.tbl_contains(lines, "Loading preview..."),
+			"expected the loading placeholder to be replaced once the preview arrives"
+		)
+	end)
+
+	it("shows an error message when the fetch failed", function()
+		local uri = "bqls://project/p/dataset/d/table/error"
+		local bufnr = vim.uri_to_bufnr(uri)
+
+		bqls.handlers["bqls/publishVirtualTextDocument"](nil, {
+			textDocument = { uri = uri },
+			kind = "details",
+			error = "boom",
+		}, { client_id = 0 })
+
+		assert.are.same({ "Error: boom" }, get_lines(bufnr))
+	end)
+
+	it("does not carry over stale details from a previous pending request", function()
+		local uri = "bqls://project/p/dataset/d/table/stale"
+		local bufnr = vim.uri_to_bufnr(uri)
+
+		bqls.handlers["bqls/publishVirtualTextDocument"](nil, {
+			textDocument = { uri = uri },
+			kind = "details",
+			contents = { "# stale details" },
+		}, { client_id = 0 })
+
+		-- A fresh request for the same uri resets to the pending placeholder,
+		-- so leftover details from the previous fetch must not leak into the
+		-- next preview.
+		bqls.handlers["bqls/virtualTextDocument"](nil, { pending = true }, {
+			client_id = 0,
+			params = { textDocument = { uri = uri } },
+		})
+
+		bqls.handlers["bqls/publishVirtualTextDocument"](nil, {
+			textDocument = { uri = uri },
+			kind = "preview",
+			result = { columns = { "id" }, data = { { 2 } } },
+		}, { client_id = 0 })
+
+		local lines = get_lines(bufnr)
+		assert.is_false(
+			vim.tbl_contains(lines, "# stale details"),
+			"expected stale details from the cancelled fetch to be discarded"
+		)
+	end)
+end)


### PR DESCRIPTION
## Summary
- kitagry/bqls#333 made `bqls/virtualTextDocument` fetching async on the server side: a client that declares `initializationOptions.supports_async_virtual_text_document` gets an immediate `{pending: true}` response instead of a blocking synchronous one, and the actual details/preview arrive later via two `bqls/publishVirtualTextDocument` notifications (`kind: "details"` then `"preview"`).
- Both `lsp/bqls.lua` and `plugin/bqls.lua` now opt in via `init_options`.
- `virtual_text_document_handler` renders a `Loading...` placeholder for a pending response instead of crashing on the missing `contents`/`result`.
- Added a `bqls/publishVirtualTextDocument` notification handler that renders details as soon as they arrive (with a `Loading preview...` placeholder), then appends the preview table once it follows. Shows `Error: <message>` if the fetch failed. Stale details are discarded when a new request for the same uri supersedes a pending one.
- Existing call sites (sidebar, execute query, definition jump, job history) are unaffected since they all share the same `M.handlers["bqls/virtualTextDocument"]`/`M.handlers["bqls/publishVirtualTextDocument"]` handlers.
- Fixed a `W10: Warning: Changing a readonly file` that the new multi-write flow would otherwise trigger, by clearing `readonly` before each write.
- Clients connected to older bqls servers (or without the opt-in) keep the original fully-synchronous behavior.

## Test plan
- [x] `make test` (all 16 specs pass, including new `tests/bqls/init_spec.lua`)
- [x] `stylua --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)