### PR TITLE
fix: render table column schema in virtualTextDocument buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,11 @@ Run the test suite (requires [plenary.nvim](https://github.com/nvim-lua/plenary.
 ```sh
 make test
 ```
+
+To manually try changes against a real bqls server without touching your own Neovim config, use the dev entrypoint (requires a `bqls` binary on your `PATH` and [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)):
+
+```sh
+nvim -u scripts/dev_init.lua
+# or against a project other than bigquery-public-data:
+BQLS_PROJECT_ID=my-project nvim -u scripts/dev_init.lua
+```

--- a/lua/bqls/commands.lua
+++ b/lua/bqls/commands.lua
@@ -45,6 +45,50 @@ M.convert_data_to_markdown = function(data)
 	return txt
 end
 
+---@class FieldSchema
+---@field name string
+---@field type string
+---@field repeated boolean|nil
+---@field required boolean|nil
+---@field description string|nil
+---@field fields FieldSchema[]|nil
+
+---@param schema FieldSchema[]
+local function write_schema_rows(lines, schema, depth)
+	local indent = string.rep("&nbsp;&nbsp;", depth)
+	for _, field in ipairs(schema) do
+		local mode = "NULLABLE"
+		if field.repeated then
+			mode = "REPEATED"
+		elseif field.required then
+			mode = "REQUIRED"
+		end
+
+		local description = field.description
+		if description == nil or description == vim.NIL then
+			description = ""
+		end
+
+		table.insert(lines, string.format("| %s%s | %s | %s | %s |", indent, field.name, field.type, mode, description))
+
+		if field.fields and field.fields ~= vim.NIL and #field.fields > 0 then
+			write_schema_rows(lines, field.fields, depth + 1)
+		end
+	end
+end
+
+---@param schema FieldSchema[]|nil
+M.convert_schema_to_markdown = function(schema)
+	if not schema or schema == vim.NIL or vim.tbl_isempty(schema) then
+		return ""
+	end
+
+	local lines = { "| Name | Type | Mode | Description |", "| --- | --- | --- | --- |" }
+	write_schema_rows(lines, schema, 0)
+
+	return table.concat(lines, "\n") .. "\n"
+end
+
 ---@param err lsp.ResponseError
 ---@param result any
 ---@param params table

--- a/lua/bqls/init.lua
+++ b/lua/bqls/init.lua
@@ -47,6 +47,12 @@ local function virtual_text_document_handler(uri, res, client_id)
 
 	local lines = util.convert_input_to_markdown_lines(res.contents)
 
+	local schema_markdown = commands.convert_schema_to_markdown(res.schema)
+	if schema_markdown ~= "" then
+		vim.list_extend(lines, { "", "### Schema", "" })
+		vim.list_extend(lines, vim.split(schema_markdown, "\n"))
+	end
+
 	local result_lines = vim.split(commands.convert_data_to_markdown(res.result), "\n")
 
 	vim.list_extend(lines, result_lines)
@@ -65,6 +71,13 @@ local function publish_virtual_text_document_handler(_, params, ctx)
 
 	if params.kind == "details" then
 		local lines = util.convert_input_to_markdown_lines(params.contents)
+
+		local schema_markdown = commands.convert_schema_to_markdown(params.schema)
+		if schema_markdown ~= "" then
+			vim.list_extend(lines, { "", "### Schema", "" })
+			vim.list_extend(lines, vim.split(schema_markdown, "\n"))
+		end
+
 		pending_details[uri] = lines
 		local buffer_lines = vim.list_extend({}, lines)
 		vim.list_extend(buffer_lines, { "", "Loading preview..." })

--- a/scripts/dev_init.lua
+++ b/scripts/dev_init.lua
@@ -1,0 +1,47 @@
+-- Manual smoke-test entrypoint for bqls.nvim: loads the plugin straight
+-- from this checkout (no plugin manager / no reinstall step) so a change
+-- can be tried against a real bqls server and BigQuery project.
+--
+-- Usage (from the plugin root):
+--   nvim -u scripts/dev_init.lua
+--
+-- Override the BigQuery project (defaults to "bigquery-public-data"):
+--   BQLS_PROJECT_ID=my-project nvim -u scripts/dev_init.lua
+
+local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h")
+vim.opt.rtp:prepend(plugin_root)
+
+-- plugin/bqls.lua registers the "bqls" server via lspconfig.configs, so
+-- nvim-lspconfig needs to be reachable too. Reuse whatever copy the
+-- user's real config already manages instead of vendoring one here.
+local lspconfig_path = vim.fn.stdpath("data") .. "/lazy/nvim-lspconfig"
+if vim.fn.isdirectory(lspconfig_path) == 1 then
+	vim.opt.rtp:append(lspconfig_path)
+else
+	vim.notify(
+		"dev_init: nvim-lspconfig not found at " .. lspconfig_path .. "; install it or edit this script",
+		vim.log.levels.WARN
+	)
+end
+
+vim.cmd("runtime! plugin/**/*.lua")
+
+local project_id = os.getenv("BQLS_PROJECT_ID") or "bigquery-public-data"
+
+vim.lsp.config("bqls", {
+	init_options = { project_id = project_id },
+})
+vim.lsp.enable("bqls")
+
+require("bqls").setup({ project_ids = { project_id } })
+
+vim.keymap.set("n", "<leader>db", function()
+	require("bqls").sidebar.toggle()
+end, { silent = true, desc = "Toggle BigQuery sidebar" })
+
+vim.api.nvim_create_autocmd("VimEnter", {
+	once = true,
+	callback = function()
+		require("bqls").sidebar.open()
+	end,
+})

--- a/tests/bqls/commands_spec.lua
+++ b/tests/bqls/commands_spec.lua
@@ -66,3 +66,60 @@ describe("bqls.commands.convert_data_to_markdown", function()
 		end
 	end)
 end)
+
+describe("bqls.commands.convert_schema_to_markdown", function()
+	it("renders a flat schema as a markdown table with name/type/mode/description", function()
+		local result = commands.convert_schema_to_markdown({
+			{ name = "id", type = "INTEGER", required = true, description = "primary key" },
+			{ name = "name", type = "STRING" },
+		})
+
+		assert.are.same(
+			"| Name | Type | Mode | Description |\n"
+				.. "| --- | --- | --- | --- |\n"
+				.. "| id | INTEGER | REQUIRED | primary key |\n"
+				.. "| name | STRING | NULLABLE |  |\n",
+			result,
+			"expected a markdown table listing each column's name, type, mode, and description"
+		)
+	end)
+
+	it("marks repeated fields as REPEATED", function()
+		local result = commands.convert_schema_to_markdown({
+			{ name = "tags", type = "STRING", repeated = true },
+		})
+
+		assert.is_true(
+			vim.tbl_contains(vim.split(result, "\n"), "| tags | STRING | REPEATED |  |"),
+			"expected the repeated field's mode to be REPEATED"
+		)
+	end)
+
+	it("indents nested RECORD fields under their parent", function()
+		local result = commands.convert_schema_to_markdown({
+			{
+				name = "address",
+				type = "RECORD",
+				fields = {
+					{ name = "city", type = "STRING" },
+				},
+			},
+		})
+
+		local lines = vim.split(result, "\n")
+		assert.is_true(
+			vim.tbl_contains(lines, "| address | RECORD | NULLABLE |  |"),
+			"expected the parent RECORD field as its own row"
+		)
+		assert.is_true(
+			vim.tbl_contains(lines, "| &nbsp;&nbsp;city | STRING | NULLABLE |  |"),
+			"expected the nested field indented under its parent"
+		)
+	end)
+
+	it("returns an empty string when the schema is empty, nil, or vim.NIL", function()
+		assert.are.same("", commands.convert_schema_to_markdown(nil))
+		assert.are.same("", commands.convert_schema_to_markdown(vim.NIL))
+		assert.are.same("", commands.convert_schema_to_markdown({}))
+	end)
+end)

--- a/tests/bqls/init_spec.lua
+++ b/tests/bqls/init_spec.lua
@@ -22,6 +22,28 @@ describe("bqls/virtualTextDocument handler", function()
 		assert.is_true(vim.tbl_contains(lines, "| id  |"), "expected the result table header in the buffer")
 	end)
 
+	it("renders the table schema when the response includes one", function()
+		local uri = "bqls://project/p/dataset/d/table/schema"
+		local bufnr = vim.uri_to_bufnr(uri)
+
+		bqls.handlers["bqls/virtualTextDocument"](nil, {
+			contents = { "# schema table" },
+			schema = {
+				{ name = "id", type = "INTEGER", required = true },
+			},
+			result = { columns = { "id" }, data = { { 1 } } },
+		}, {
+			client_id = 0,
+			params = { textDocument = { uri = uri } },
+		})
+
+		local lines = get_lines(bufnr)
+		assert.is_true(
+			vim.tbl_contains(lines, "| id | INTEGER | REQUIRED |  |"),
+			"expected the table's column schema to be rendered in the buffer"
+		)
+	end)
+
 	it("shows a loading placeholder instead of crashing when the response is pending", function()
 		local uri = "bqls://project/p/dataset/d/table/pending"
 		local bufnr = vim.uri_to_bufnr(uri)
@@ -51,6 +73,26 @@ describe("bqls/publishVirtualTextDocument handler", function()
 		assert.is_true(
 			vim.tbl_contains(lines, "Loading preview..."),
 			"expected a placeholder for the not-yet-arrived preview"
+		)
+	end)
+
+	it("renders the table schema included with the details notification", function()
+		local uri = "bqls://project/p/dataset/d/table/details-schema"
+		local bufnr = vim.uri_to_bufnr(uri)
+
+		bqls.handlers["bqls/publishVirtualTextDocument"](nil, {
+			textDocument = { uri = uri },
+			kind = "details",
+			contents = { "# details table" },
+			schema = {
+				{ name = "id", type = "INTEGER", required = true },
+			},
+		}, { client_id = 0 })
+
+		local lines = get_lines(bufnr)
+		assert.is_true(
+			vim.tbl_contains(lines, "| id | INTEGER | REQUIRED |  |"),
+			"expected the table's column schema to be rendered in the buffer"
 		)
 	end)
 


### PR DESCRIPTION
## Summary
- bqls now returns a structured `schema` field (name/type/mode/description, with nested RECORD fields) alongside `contents`/`result` on both the sync `bqls/virtualTextDocument` response and the async `bqls/publishVirtualTextDocument` "details" notification, but the nvim handlers ignored it entirely — leaving column info missing whenever the preview couldn't supply it (e.g. views, where no preview rows are fetched).
- Add `commands.convert_schema_to_markdown` to render the schema tree as a markdown table (mirroring the server's own schema table format), and wire it into both handlers in `lua/bqls/init.lua`.
- Add `scripts/dev_init.lua` so changes can be smoke-tested against a real bqls server/BigQuery project via `nvim -u scripts/dev_init.lua`, without touching a personal Neovim config.

## Test plan
- [x] `make test` passes (added coverage for `convert_schema_to_markdown` and both handlers rendering schema)
- [x] `nvim -u scripts/dev_init.lua` boots cleanly (headless smoke check, no Lua errors, no leftover `bqls` process)
- [ ] Manually confirm the `### Schema` section renders columns when opening a table in the sidebar against a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)