### PR TITLE
feat: add :BqlsCancelQuery to cancel a running query

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ vim.lsp.buf_notify(0, "workspace/didChangeConfiguration", {
 You can choose `lua vim.lsp.buf.code_action()`.
 In order to save result to local file, you can use `:BqlsSave ./path/to/file.csv`.
 
+While a query is still running (the result buffer shows `Loading...`), run `:BqlsCancelQuery` from that buffer to cancel it. Running it after the query has already finished is a no-op with a warning, since there is nothing left to cancel.
+
+> **Note:** Cancelling a query requires bqls server support for the `bqls.cancelQuery` command.
+
 https://github.com/user-attachments/assets/2f5aef83-f341-4c04-bb37-88db45badb6d
 
 ## BigQuery Explorer (Sidebar)

--- a/lua/bqls/commands.lua
+++ b/lua/bqls/commands.lua
@@ -238,6 +238,34 @@ M.save_result_handler = function(err, result, params)
 	vim.notify("bqls: save result to " .. result.url, vim.log.levels.INFO)
 end
 
+---@param err lsp.ResponseError
+---@param result any
+M.cancel_query_handler = function(err, result)
+	if err then
+		vim.notify("bqls: " .. err.message, vim.log.levels.ERROR)
+		return
+	end
+	vim.notify("bqls: query cancelled", vim.log.levels.INFO)
+end
+
+---@param bufnr integer buffer number of the virtual document showing the running query
+--- Sends `bqls.cancelQuery` for the job backing this buffer, identified by its
+--- `bqls://` uri. Skipped (with a warning) once the buffer no longer shows the
+--- "Loading..." placeholder, since the query has already finished by then.
+M.cancel_query = function(bufnr)
+	local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+	if not (#lines == 1 and lines[1] == "Loading...") then
+		vim.notify("bqls: no running query to cancel", vim.log.levels.WARN)
+		return
+	end
+
+	local uri = vim.uri_from_bufnr(bufnr)
+	vim.lsp.buf_request(bufnr, "workspace/executeCommand", {
+		command = "bqls.cancelQuery",
+		arguments = { uri },
+	}, M.cancel_query_handler)
+end
+
 ---@param project_id string Google Cloud project id
 ---@param callback fun(request_results: table<integer, {error: lsp.ResponseError, result: any}>) (function)
 --- The callback to call when all requests are finished.

--- a/plugin/bqls.lua
+++ b/plugin/bqls.lua
@@ -38,6 +38,10 @@ vim.api.nvim_create_autocmd({ "BufEnter", "BufFilePost" }, {
 				arguments = { vim.fn.expand("%:p"), file_path },
 			}, require("bqls").handlers["workspace/executeCommand"])
 		end, { desc = "Save bqls result", nargs = "*" })
+
+		vim.api.nvim_buf_create_user_command(0, "BqlsCancelQuery", function()
+			require("bqls.commands").cancel_query(0)
+		end, { desc = "Cancel the running bqls query" })
 	end,
 })
 vim.api.nvim_create_autocmd("BufNew", {

--- a/tests/bqls/commands_spec.lua
+++ b/tests/bqls/commands_spec.lua
@@ -123,3 +123,94 @@ describe("bqls.commands.convert_schema_to_markdown", function()
 		assert.are.same("", commands.convert_schema_to_markdown({}))
 	end)
 end)
+
+describe("bqls.commands.cancel_query", function()
+	local original_buf_request
+	local original_notify
+
+	before_each(function()
+		original_buf_request = vim.lsp.buf_request
+		original_notify = vim.notify
+	end)
+
+	after_each(function()
+		vim.lsp.buf_request = original_buf_request
+		vim.notify = original_notify
+	end)
+
+	it("sends bqls.cancelQuery with the buffer's job uri when a query is pending", function()
+		local uri = "bqls://project/p/job/j/location/l"
+		local bufnr = vim.uri_to_bufnr(uri)
+		vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "Loading..." })
+
+		local requested
+		vim.lsp.buf_request = function(bufnr_arg, method, params, handler)
+			requested = { bufnr = bufnr_arg, method = method, params = params, handler = handler }
+		end
+
+		commands.cancel_query(bufnr)
+
+		assert.is_not_nil(requested, "expected a workspace/executeCommand request to be sent")
+		assert.are.same("workspace/executeCommand", requested.method)
+		assert.are.same("bqls.cancelQuery", requested.params.command)
+		assert.are.same({ uri }, requested.params.arguments)
+		assert.are.same(bufnr, requested.bufnr)
+		assert.is_function(requested.handler)
+	end)
+
+	it("does not send a request and warns when the buffer is not showing a pending query", function()
+		local uri = "bqls://project/p/job/j/location/l2"
+		local bufnr = vim.uri_to_bufnr(uri)
+		vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "| id |", "| :---: |", "| 1 |" })
+
+		local requested = false
+		vim.lsp.buf_request = function()
+			requested = true
+		end
+
+		local notified_level
+		vim.notify = function(_, level)
+			notified_level = level
+		end
+
+		commands.cancel_query(bufnr)
+
+		assert.is_false(requested, "expected no request to be sent once the query already finished")
+		assert.are.same(vim.log.levels.WARN, notified_level, "expected a warning explaining there is nothing to cancel")
+	end)
+end)
+
+describe("bqls.commands.cancel_query_handler", function()
+	local original_notify
+
+	before_each(function()
+		original_notify = vim.notify
+	end)
+
+	after_each(function()
+		vim.notify = original_notify
+	end)
+
+	it("notifies success when the server cancels the query", function()
+		local notified
+		vim.notify = function(msg, level)
+			notified = { msg = msg, level = level }
+		end
+
+		commands.cancel_query_handler(nil, nil, {})
+
+		assert.are.same(vim.log.levels.INFO, notified.level, "expected an info notification on success")
+	end)
+
+	it("notifies an error when the server fails to cancel the query", function()
+		local notified
+		vim.notify = function(msg, level)
+			notified = { msg = msg, level = level }
+		end
+
+		commands.cancel_query_handler({ message = "boom" }, nil, {})
+
+		assert.are.same("bqls: boom", notified.msg, "expected the server error message to be surfaced")
+		assert.are.same(vim.log.levels.ERROR, notified.level)
+	end)
+end)


### PR DESCRIPTION
## Summary
- bqls本体の未マージPR [kitagry/bqls#361](https://github.com/kitagry/bqls/pull/361) で追加される `bqls.cancelQuery` (`workspace/executeCommand`) に対応
- クエリ結果のvirtual documentバッファで `:BqlsCancelQuery` を実行すると、そのバッファのjob uriでキャンセルリクエストを送信
- バッファが `Loading...` を表示している(=クエリ実行中)場合のみリクエストを送信し、既に完了している場合は警告を出すだけで実害なし
- 成功/失敗どちらも `vim.notify` でフィードバック
- READMEに使い方を追記

## Test plan
- [x] `make test` が全件成功 (`lua/bqls/commands.lua` の `cancel_query` / `cancel_query_handler` にユニットテストを追加、TDDで実装)
- [ ] bqls#361 がmainにマージされ、対応バイナリをビルドした後に実サーバーとのE2E動作確認